### PR TITLE
Fix "Bad -I option" messages during `make depend`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ tis-interpreter/tis-mkfs
 *.tar.gz
 
 doc/code/docgen.ml
-lib/
 src/kernel_internals/parsing/clexer.ml
 src/kernel_internals/parsing/cparser.ml
 src/kernel_internals/parsing/cparser.mli
@@ -42,4 +41,3 @@ src/plugins/report/Makefile
 src/plugins/security_slicing/Makefile
 src/plugins/wp/Makefile
 tis-interpreter/tis-interpreter/
-

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,3 @@
+*
+!/.gitignore
+!/plugins/

--- a/lib/plugins/.gitignore
+++ b/lib/plugins/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
The following messages appear during `make depend` because the
`lib/plugins` directory do not exist:

    Bad -I option: lib: No such file or directory
    Bad -I option: .../tis-interpreter/lib/plugins: No such file or directory

Adding the directory to the git repository seems easier than updating
the Makefile with `mkdir -p lib/plugins` as the expected place.