### PR TITLE
Protect macros defined in the standard library

### DIFF
--- a/share/libc/fcntl.h
+++ b/share/libc/fcntl.h
@@ -63,7 +63,7 @@ struct flock
 
 #include "__fc_define_seek_macros.h"
 
-# define AT_FDCWD		-100	/* Special value used to indicate
+# define AT_FDCWD		(-100)	/* Special value used to indicate
 					   the *at functions should use the
 					   current working directory. */
 # define AT_SYMLINK_NOFOLLOW	0x100	/* Do not follow symbolic links.  */

--- a/share/libc/features.h
+++ b/share/libc/features.h
@@ -53,7 +53,7 @@
 // the compiler were unable to statically determine
 // the object size (we only consider the cases where type
 // is either 0 or 1).
-#define __builtin_object_size (ptr, type) ((size_t)-1)
+#define __builtin_object_size(ptr, type) ((size_t)-1)
 #define __bos(ptr) __builtin_object_size (ptr, 0)
 #define __bos0(ptr) __builtin_object_size (ptr, 0)
 

--- a/share/libc/netdb.h
+++ b/share/libc/netdb.h
@@ -97,16 +97,16 @@ struct addrinfo
 # define NI_DGRAM	16	/* Look up UDP service rather than TCP.  */
 # define NI_NUMERICSCOPE 32
 
-# define EAI_BADFLAGS	  -1	/* Invalid value for `ai_flags' field.  */
-# define EAI_NONAME	  -2	/* NAME or SERVICE is unknown.  */
-# define EAI_AGAIN	  -3	/* Temporary failure in name resolution.  */
-# define EAI_FAIL	  -4	/* Non-recoverable failure in name res.  */
-# define EAI_FAMILY	  -6	/* `ai_family' not supported.  */
-# define EAI_SOCKTYPE	  -7	/* `ai_socktype' not supported.  */
-# define EAI_SERVICE	  -8	/* SERVICE not supported for `ai_socktype'.  */
-# define EAI_MEMORY	  -10	/* Memory allocation failure.  */
-# define EAI_SYSTEM	  -11	/* System error returned in `errno'.  */
-# define EAI_OVERFLOW	  -12	/* Argument buffer overflow.  */
+# define EAI_BADFLAGS	  (-1)	/* Invalid value for `ai_flags' field.  */
+# define EAI_NONAME	  (-2)	/* NAME or SERVICE is unknown.  */
+# define EAI_AGAIN	  (-3)	/* Temporary failure in name resolution.  */
+# define EAI_FAIL	  (-4)	/* Non-recoverable failure in name res.  */
+# define EAI_FAMILY	  (-6)	/* `ai_family' not supported.  */
+# define EAI_SOCKTYPE	  (-7)	/* `ai_socktype' not supported.  */
+# define EAI_SERVICE	  (-8)	/* SERVICE not supported for `ai_socktype'.  */
+# define EAI_MEMORY	  (-10)	/* Memory allocation failure.  */
+# define EAI_SYSTEM	  (-11)	/* System error returned in `errno'.  */
+# define EAI_OVERFLOW	  (-12)	/* Argument buffer overflow.  */
 
 void endhostent(void);
 void endnetent(void);

--- a/share/libc/sys/socket.h
+++ b/share/libc/sys/socket.h
@@ -126,7 +126,7 @@ struct msghdr {
 #define SO_USELOOPBACK  0x0040          /* bypass hardware when possible */
 #define SO_LINGER       0x0080          /* linger on close if data present */
 #define SO_OOBINLINE    0x0100          /* leave received OOB data in line */
-#define SO_DONTLINGER   (unsigned int)(~SO_LINGER)
+#define SO_DONTLINGER   ((unsigned int)(~SO_LINGER))
 #define SO_PEERCRED	0x0200		/* same as getpeereid */
 
 #define SO_ERROR        0x1000


### PR DESCRIPTION
Fix the second batch of macros provided in #50.
